### PR TITLE
wasm demo completions support

### DIFF
--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -1195,6 +1195,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_ide_api 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_syntax 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
+ "ra_text_edit 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-wasm-bindgen 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -1000,6 +1000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1197,7 @@ dependencies = [
  "ra_syntax 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-wasm-bindgen 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1346,6 +1357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde-wasm-bindgen 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee6f12f7ed0e7ad2e55200da37dbabc2cadeb942355c5b629aa3771f5ac5636"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cd02c7587ec314570041b2754829f84d873ced14a96d1fd1823531e11db40573"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum smol_str 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "590700be3630457c56f8c73c0ea39881476ad7076cd84057d44f4f38f79914fb"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -18,3 +18,4 @@ serde-wasm-bindgen = "0.1"
 
 ra_ide_api = { git = "https://github.com/rust-analyzer/rust-analyzer", features = ["wasm"] }
 ra_syntax =  { git = "https://github.com/rust-analyzer/rust-analyzer" }
+ra_text_edit =  { git = "https://github.com/rust-analyzer/rust-analyzer" }

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -13,6 +13,7 @@ console_log = "0.1"
 log = "0.4"
 wasm-bindgen = "0.2.50"
 serde = { version = "1.0", features = ["derive"] }
+serde_repr = "0.1"
 serde-wasm-bindgen = "0.1"
 
 ra_ide_api = { git = "https://github.com/rust-analyzer/rust-analyzer", features = ["wasm"] }

--- a/wasm-demo/rustfmt.toml
+++ b/wasm-demo/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_modules = false
+use_small_heuristics = "Max"
+newline_style = "Unix"

--- a/wasm-demo/src/conv.rs
+++ b/wasm-demo/src/conv.rs
@@ -1,0 +1,72 @@
+use super::return_types;
+use ra_ide_api::{CompletionItemKind, FileId, FilePosition, LineCol, LineIndex};
+use ra_syntax::TextRange;
+
+pub trait Conv {
+    type Output;
+    fn conv(self) -> Self::Output;
+}
+
+pub trait ConvWith<CTX> {
+    type Output;
+    fn conv_with(self, ctx: CTX) -> Self::Output;
+}
+
+#[derive(Clone, Copy)]
+pub struct Position {
+    pub line_number: u32,
+    pub column: u32,
+}
+
+impl ConvWith<(&LineIndex, FileId)> for Position {
+    type Output = FilePosition;
+
+    fn conv_with(self, (line_index, file_id): (&LineIndex, FileId)) -> Self::Output {
+        let line_col = LineCol { line: self.line_number - 1, col_utf16: self.column - 1 };
+        let offset = line_index.offset(line_col);
+        FilePosition { file_id, offset }
+    }
+}
+
+impl ConvWith<&LineIndex> for TextRange {
+    type Output = return_types::Range;
+
+    fn conv_with(self, line_index: &LineIndex) -> Self::Output {
+        let start = line_index.line_col(self.start());
+        let end = line_index.line_col(self.end());
+
+        return_types::Range {
+            startLineNumber: start.line + 1,
+            startColumn: start.col_utf16 + 1,
+            endLineNumber: end.line + 1,
+            endColumn: end.col_utf16 + 1,
+        }
+    }
+}
+
+impl Conv for CompletionItemKind {
+    type Output = return_types::CompletionItemKind;
+
+    fn conv(self) -> <Self as Conv>::Output {
+        use return_types::CompletionItemKind::*;
+        match self {
+            CompletionItemKind::Keyword => Keyword,
+            CompletionItemKind::Snippet => Snippet,
+            CompletionItemKind::Module => Module,
+            CompletionItemKind::Function => Function,
+            CompletionItemKind::Struct => Struct,
+            CompletionItemKind::Enum => Enum,
+            CompletionItemKind::EnumVariant => EnumMember,
+            CompletionItemKind::BuiltinType => Struct,
+            CompletionItemKind::Binding => Variable,
+            CompletionItemKind::Field => Field,
+            CompletionItemKind::Trait => Interface,
+            CompletionItemKind::TypeAlias => Struct,
+            CompletionItemKind::Const => Constant,
+            CompletionItemKind::Static => Value,
+            CompletionItemKind::Method => Method,
+            CompletionItemKind::TypeParam => TypeParameter,
+            CompletionItemKind::Macro => Method,
+        }
+    }
+}

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg(target_arch = "wasm32")]
 #![allow(non_snake_case)]
 
-use ra_ide_api::{Analysis, CompletionItemKind, FileId, FilePosition, InsertTextFormat, Severity};
+use ra_ide_api::{Analysis, FileId, FilePosition, Severity};
 use ra_syntax::SyntaxKind;
 use wasm_bindgen::prelude::*;
 
@@ -82,26 +82,7 @@ impl WorldState {
             None => return JsValue::NULL,
         };
 
-        log::warn!("{:#?}", res);
-
-        let items: Vec<_> = res
-            .into_iter()
-            .map(|item| CompletionItem {
-                kind: item.kind().unwrap_or(CompletionItemKind::Struct).conv(),
-                label: item.label().to_string(),
-                range: item.source_range().conv_with(&line_index),
-                detail: item.detail().map(|it| it.to_string()),
-                insertText: item.text_edit().as_atoms()[0].insert.clone(),
-                insertTextRules: match item.insert_text_format() {
-                    InsertTextFormat::PlainText => CompletionItemInsertTextRule::None,
-                    InsertTextFormat::Snippet => CompletionItemInsertTextRule::InsertAsSnippet,
-                },
-                documentation: item
-                    .documentation()
-                    .map(|doc| MarkdownString { value: doc.as_str().to_string() }),
-                filterText: item.lookup().to_string(),
-            })
-            .collect();
+        let items: Vec<_> = res.into_iter().map(|item| item.conv_with(&line_index)).collect();
         serde_wasm_bindgen::to_value(&items).unwrap()
     }
 

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -77,6 +77,7 @@ pub struct CompletionItem {
     pub insertTextRules: CompletionItemInsertTextRule,
     pub documentation: Option<MarkdownString>,
     pub filterText: String,
+    pub additionalTextEdits: Vec<TextEdit>,
 }
 
 #[allow(dead_code)]
@@ -108,7 +109,7 @@ pub enum CompletionItemKind {
     Customcolor = 22,
     Folder = 23,
     TypeParameter = 24,
-    Snippet = 25
+    Snippet = 25,
 }
 
 #[allow(dead_code)]
@@ -117,12 +118,12 @@ pub enum CompletionItemKind {
 pub enum CompletionItemInsertTextRule {
     None = 0,
     /**
-      * Adjust whitespace/indentation of multiline insert texts to
-      * match the current line indentation.
-      */
+     * Adjust whitespace/indentation of multiline insert texts to
+     * match the current line indentation.
+     */
     KeepWhitespace = 1,
     /**
-      * `insertText` is a snippet.
-      */
+     * `insertText` is a snippet.
+     */
     InsertAsSnippet = 4,
 }

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_repr::Serialize_repr;
 
 #[derive(Serialize)]
 pub struct Hover {
@@ -70,7 +71,58 @@ pub struct RenameLocation {
 pub struct CompletionItem {
     pub label: String,
     pub range: Range,
-    pub kind: u32,
+    pub kind: CompletionItemKind,
     pub detail: Option<String>,
     pub insertText: String,
+    pub insertTextRules: CompletionItemInsertTextRule,
+    pub documentation: Option<MarkdownString>,
+    pub filterText: String,
+}
+
+#[allow(dead_code)]
+#[derive(Serialize_repr)]
+#[repr(u8)]
+pub enum CompletionItemKind {
+    Method = 0,
+    Function = 1,
+    Constructor = 2,
+    Field = 3,
+    Variable = 4,
+    Class = 5,
+    Struct = 6,
+    Interface = 7,
+    Module = 8,
+    Property = 9,
+    Event = 10,
+    Operator = 11,
+    Unit = 12,
+    Value = 13,
+    Constant = 14,
+    Enum = 15,
+    EnumMember = 16,
+    Keyword = 17,
+    Text = 18,
+    Color = 19,
+    File = 20,
+    Reference = 21,
+    Customcolor = 22,
+    Folder = 23,
+    TypeParameter = 24,
+    Snippet = 25
+}
+
+#[allow(dead_code)]
+#[derive(Serialize_repr)]
+#[repr(u8)]
+pub enum CompletionItemInsertTextRule {
+    None = 0,
+    /**
+      * Adjust whitespace/indentation of multiline insert texts to
+      * match the current line indentation.
+      */
+    KeepWhitespace = 1,
+    /**
+      * `insertText` is a snippet.
+      */
+    InsertAsSnippet = 4,
 }

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -65,3 +65,12 @@ pub struct RenameLocation {
     pub range: Range,
     pub text: String,
 }
+
+#[derive(Serialize)]
+pub struct CompletionItem {
+    pub label: String,
+    pub range: Range,
+    pub kind: u32,
+    pub detail: Option<String>,
+    pub insertText: String,
+}

--- a/wasm-demo/www/index.js
+++ b/wasm-demo/www/index.js
@@ -135,6 +135,15 @@ monaco.languages.onLanguage(modeId, async () => {
         },
         resolveRenameLocation: (_, pos) => state.prepare_rename(pos.lineNumber, pos.column),
     });
+    monaco.languages.registerCompletionItemProvider(modeId, {
+        triggerCharacters: [".", ":", "="],
+        provideCompletionItems(m, pos, ctx) {
+            console.warn(ctx)
+            const suggestions = state.completions(pos.lineNumber, pos.column)
+            console.warn(suggestions)
+            return { suggestions }
+        },
+    });
 
     class TokenState {
         constructor(line = 0) {

--- a/wasm-demo/www/index.js
+++ b/wasm-demo/www/index.js
@@ -146,10 +146,8 @@ monaco.languages.onLanguage(modeId, async () => {
     });
     monaco.languages.registerCompletionItemProvider(modeId, {
         triggerCharacters: [".", ":", "="],
-        provideCompletionItems(m, pos, ctx) {
-            console.warn(ctx)
+        provideCompletionItems(m, pos) {
             const suggestions = state.completions(pos.lineNumber, pos.column)
-            console.warn(suggestions)
             return { suggestions }
         },
     });


### PR DESCRIPTION
Adds basic typing completions support to the wasm demo. Things such as functions, the rust-analyzer helpers (box, dbg...) work now.
This includes some refactoring to have the same `Conv` and `ConvWith<CTX>` as used in ra_lsp_server.
