### PR TITLE
Another bunch of wasm demo functionality

### DIFF
--- a/wasm-demo/Cargo.lock
+++ b/wasm-demo/Cargo.lock
@@ -15,11 +15,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.37"
+version = "0.3.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -77,13 +77,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chalk-engine"
 version = "0.9.0"
-source = "git+https://github.com/rust-lang/chalk.git#b4a6b655578ee35b1b3f6b8579636269cf3b0b1a"
+source = "git+https://github.com/rust-lang/chalk.git#df09cc603c0cff9ed95e5554055d483fdd756fbc"
 dependencies = [
  "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
  "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 name = "chalk-ir"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b4a6b655578ee35b1b3f6b8579636269cf3b0b1a"
+source = "git+https://github.com/rust-lang/chalk.git#df09cc603c0cff9ed95e5554055d483fdd756fbc"
 dependencies = [
  "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
  "chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)",
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "chalk-macros"
 version = "0.1.1"
-source = "git+https://github.com/rust-lang/chalk.git#b4a6b655578ee35b1b3f6b8579636269cf3b0b1a"
+source = "git+https://github.com/rust-lang/chalk.git#df09cc603c0cff9ed95e5554055d483fdd756fbc"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "chalk-rust-ir"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b4a6b655578ee35b1b3f6b8579636269cf3b0b1a"
+source = "git+https://github.com/rust-lang/chalk.git#df09cc603c0cff9ed95e5554055d483fdd756fbc"
 dependencies = [
  "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
  "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "chalk-solve"
 version = "0.1.0"
-source = "git+https://github.com/rust-lang/chalk.git#b4a6b655578ee35b1b3f6b8579636269cf3b0b1a"
+source = "git+https://github.com/rust-lang/chalk.git#df09cc603c0cff9ed95e5554055d483fdd756fbc"
 dependencies = [
  "chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)",
  "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
@@ -139,7 +139,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ name = "console_error_panic_hook"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -165,7 +165,7 @@ name = "crossbeam"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -196,7 +196,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -216,7 +216,7 @@ name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -225,7 +225,7 @@ name = "derive-new"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -258,7 +258,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -306,7 +306,7 @@ name = "getrandom"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -378,7 +378,7 @@ name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -449,7 +449,7 @@ name = "parking_lot_core"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -494,7 +494,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -523,36 +523,37 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ra_arena"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 
 [[package]]
 name = "ra_assists"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "format-buf 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "join_to_string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_db 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_fmt 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_hir 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_syntax 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_text_edit 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
 ]
 
 [[package]]
 name = "ra_db"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "ra_prof 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_syntax 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
@@ -564,7 +565,7 @@ dependencies = [
 [[package]]
 name = "ra_fmt"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_syntax 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
@@ -573,7 +574,7 @@ dependencies = [
 [[package]]
 name = "ra_hir"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)",
@@ -582,7 +583,7 @@ dependencies = [
  "ena 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-intern 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_arena 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_db 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
@@ -598,7 +599,7 @@ dependencies = [
 [[package]]
 name = "ra_ide_api"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "format-buf 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fst 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,7 +625,7 @@ dependencies = [
 [[package]]
 name = "ra_mbe"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -638,7 +639,7 @@ dependencies = [
 [[package]]
 name = "ra_parser"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "drop_bomb 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -646,22 +647,23 @@ dependencies = [
 [[package]]
 name = "ra_prof"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
- "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ra_syntax"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ra_parser 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "ra_text_edit 0.1.0 (git+https://github.com/rust-analyzer/rust-analyzer)",
  "rowan 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_lexer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smol_str 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -669,7 +671,7 @@ dependencies = [
 [[package]]
 name = "ra_text_edit"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_unit 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -678,7 +680,7 @@ dependencies = [
 [[package]]
 name = "ra_tt"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "smol_str 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -937,7 +939,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -984,7 +986,7 @@ name = "serde_derive"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1004,7 +1006,7 @@ name = "serde_repr"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1033,7 +1035,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1058,7 +1060,7 @@ name = "syn"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1077,7 +1079,7 @@ dependencies = [
 [[package]]
 name = "test_utils"
 version = "0.1.0"
-source = "git+https://github.com/rust-analyzer/rust-analyzer#07bbe57fefdf8d7041c8bdeb0f3feb7ca567c43b"
+source = "git+https://github.com/rust-analyzer/rust-analyzer#870ce4b1a50a07e3a536ab26215804acdfc9ba8a"
 dependencies = [
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1127,7 +1129,7 @@ name = "wasm-bindgen"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1139,7 +1141,7 @@ dependencies = [
  "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1161,7 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1179,7 +1181,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1244,16 +1246,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
-"checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
+"checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chalk-engine 0.9.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
 "checksum chalk-ir 0.1.0 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
 "checksum chalk-macros 0.1.1 (git+https://github.com/rust-lang/chalk.git)" = "<none>"
@@ -1298,14 +1300,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum once_cell 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a04cb71e910d0034815600180f62a95bf6e67942d7ab52a166a68c7d7e9cd0"
+"checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
+"checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"

--- a/wasm-demo/Cargo.toml
+++ b/wasm-demo/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+dev = ["console_log", "console_error_panic_hook"]
+
 [dependencies]
-console_error_panic_hook = "0.1.6"
-console_log = "0.1"
-log = "0.4"
+console_error_panic_hook = { version = "0.1", optional = true }
+console_log = { version = "0.1", optional = true }
+log = { version = "0.4", features = ["release_max_level_warn"] }
 wasm-bindgen = "0.2.50"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"

--- a/wasm-demo/src/conv.rs
+++ b/wasm-demo/src/conv.rs
@@ -3,7 +3,7 @@ use ra_ide_api::{
     CompletionItem, CompletionItemKind, Documentation, FileId, FilePosition, FunctionSignature,
     InsertTextFormat, LineCol, LineIndex, NavigationTarget, RangeInfo, Severity,
 };
-use ra_syntax::TextRange;
+use ra_syntax::{SyntaxKind, TextRange};
 use ra_text_edit::AtomTextEdit;
 
 pub trait Conv {
@@ -212,5 +212,27 @@ impl ConvWith<&LineIndex> for RangeInfo<Vec<NavigationTarget>> {
                 }
             })
             .collect()
+    }
+}
+
+impl Conv for SyntaxKind {
+    type Output = return_types::SymbolKind;
+
+    fn conv(self) -> Self::Output {
+        use return_types::SymbolKind;
+        match self {
+            SyntaxKind::FN_DEF => SymbolKind::Function,
+            SyntaxKind::STRUCT_DEF => SymbolKind::Struct,
+            SyntaxKind::ENUM_DEF => SymbolKind::Enum,
+            SyntaxKind::ENUM_VARIANT => SymbolKind::EnumMember,
+            SyntaxKind::TRAIT_DEF => SymbolKind::Interface,
+            SyntaxKind::MODULE => SymbolKind::Module,
+            SyntaxKind::TYPE_ALIAS_DEF => SymbolKind::TypeParameter,
+            SyntaxKind::RECORD_FIELD_DEF => SymbolKind::Field,
+            SyntaxKind::STATIC_DEF => SymbolKind::Constant,
+            SyntaxKind::CONST_DEF => SymbolKind::Constant,
+            SyntaxKind::IMPL_BLOCK => SymbolKind::Object,
+            _ => SymbolKind::Variable,
+        }
     }
 }

--- a/wasm-demo/src/lib.rs
+++ b/wasm-demo/src/lib.rs
@@ -12,8 +12,11 @@ use return_types::*;
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Warn).expect("could not install logging hook");
+    #[cfg(feature = "dev")]
+    {
+        console_error_panic_hook::set_once();
+        console_log::init_with_level(log::Level::Warn).expect("could not install logging hook");
+    }
     log::info!("worker initialized")
 }
 
@@ -129,7 +132,7 @@ impl WorldState {
                 let positions = nav_info
                     .info
                     .iter()
-                    .map(|target| target.focus_range().unwrap_or(target.full_range()))
+                    .map(|target| target.focus_range().unwrap_or_else(|| target.full_range()))
                     .map(|range| range.conv_with(&line_index))
                     .collect();
 

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -216,6 +216,7 @@ pub struct DocumentSymbol {
     pub children: Option<Vec<DocumentSymbol>>,
 }
 
+#[allow(dead_code)]
 #[derive(Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FoldingRangeKind {

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -163,3 +163,55 @@ pub struct LocationLink {
     pub range: Range,
     pub targetSelectionRange: Range,
 }
+
+#[allow(dead_code)]
+#[derive(Serialize_repr)]
+#[repr(u8)]
+pub enum SymbolTag {
+    None = 0,
+    Deprecated = 1,
+}
+
+#[allow(dead_code)]
+#[derive(Serialize_repr)]
+#[repr(u8)]
+pub enum SymbolKind {
+    File = 0,
+    Module = 1,
+    Namespace = 2,
+    Package = 3,
+    Class = 4,
+    Method = 5,
+    Property = 6,
+    Field = 7,
+    Constructor = 8,
+    Enum = 9,
+    Interface = 10,
+    Function = 11,
+    Variable = 12,
+    Constant = 13,
+    String = 14,
+    Number = 15,
+    Boolean = 16,
+    Array = 17,
+    Object = 18,
+    Key = 19,
+    Null = 20,
+    EnumMember = 21,
+    Struct = 22,
+    Event = 23,
+    Operator = 24,
+    TypeParameter = 25,
+}
+
+#[derive(Serialize)]
+pub struct DocumentSymbol {
+    pub name: String,
+    pub detail: String,
+    pub kind: SymbolKind,
+    pub tags: [SymbolTag; 1],
+    pub containerName: Option<String>,
+    pub range: Range,
+    pub selectionRange: Range,
+    pub children: Option<Vec<DocumentSymbol>>,
+}

--- a/wasm-demo/src/return_types.rs
+++ b/wasm-demo/src/return_types.rs
@@ -215,3 +215,18 @@ pub struct DocumentSymbol {
     pub selectionRange: Range,
     pub children: Option<Vec<DocumentSymbol>>,
 }
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FoldingRangeKind {
+    Comment,
+    Imports,
+    Region,
+}
+
+#[derive(Serialize)]
+pub struct FoldingRange {
+    pub start: u32,
+    pub end: u32,
+    pub kind: Option<FoldingRangeKind>,
+}

--- a/wasm-demo/www/index.js
+++ b/wasm-demo/www/index.js
@@ -126,10 +126,15 @@ monaco.languages.onLanguage(modeId, async () => {
         },
     });
     monaco.languages.registerReferenceProvider(modeId, {
-        provideReferences: (m, pos) => state.references(pos.lineNumber, pos.column).map(({ range }) => ({ uri: m.uri, range })),
+        provideReferences(m, pos, { includeDeclaration }) {
+            const references = state.references(pos.lineNumber, pos.column, includeDeclaration);
+            if (references) {
+                return references.map(({ range }) => ({ uri: m.uri, range }));
+            }
+        },
     });
     monaco.languages.registerDocumentHighlightProvider(modeId, {
-        provideDocumentHighlights: (_, pos) => state.references(pos.lineNumber, pos.column),
+        provideDocumentHighlights: (_, pos) => state.references(pos.lineNumber, pos.column, true),
     });
     monaco.languages.registerRenameProvider(modeId, {
         provideRenameEdits: (m, pos, newName) => {
@@ -176,6 +181,14 @@ monaco.languages.onLanguage(modeId, async () => {
     monaco.languages.registerTypeDefinitionProvider(modeId, {
         provideTypeDefinition(m, pos) {
             const list = state.type_definition(pos.lineNumber, pos.column);
+            if (list) {
+                return list.map(def => ({ ...def, uri: m.uri }));
+            }
+        },
+    });
+    monaco.languages.registerImplementationProvider(modeId, {
+        provideImplementation(m, pos) {
+            const list = state.goto_implementation(pos.lineNumber, pos.column);
             if (list) {
                 return list.map(def => ({ ...def, uri: m.uri }));
             }

--- a/wasm-demo/www/index.js
+++ b/wasm-demo/www/index.js
@@ -134,13 +134,14 @@ monaco.languages.onLanguage(modeId, async () => {
     monaco.languages.registerRenameProvider(modeId, {
         provideRenameEdits: (m, pos, newName) => {
             const edits = state.rename(pos.lineNumber, pos.column, newName);
-            if (!edits) return null;
-            return {
-                edits: [{
-                    resource: m.uri,
-                    edits,
-                }],
-            };
+            if (edits) {
+                return {
+                    edits: [{
+                        resource: m.uri,
+                        edits,
+                    }],
+                };
+            }
         },
         resolveRenameLocation: (_, pos) => state.prepare_rename(pos.lineNumber, pos.column),
     });
@@ -148,7 +149,9 @@ monaco.languages.onLanguage(modeId, async () => {
         triggerCharacters: [".", ":", "="],
         provideCompletionItems(m, pos) {
             const suggestions = state.completions(pos.lineNumber, pos.column);
-            return { suggestions };
+            if (suggestions) {
+                return { suggestions };
+            }
         },
     });
     monaco.languages.registerSignatureHelpProvider(modeId, {
@@ -163,13 +166,24 @@ monaco.languages.onLanguage(modeId, async () => {
         },
     });
     monaco.languages.registerDefinitionProvider(modeId, {
-        provideDefinition: (m, pos) => state.definition(pos.lineNumber, pos.column)
-            .map(def => ({ ...def, uri: m.uri })),
+        provideDefinition(m, pos) {
+            const list = state.definition(pos.lineNumber, pos.column);
+            if (list) {
+                return list.map(def => ({ ...def, uri: m.uri }));
+            }
+        },
     });
     monaco.languages.registerTypeDefinitionProvider(modeId, {
-        provideTypeDefinition: (m, pos) => state.type_definition(pos.lineNumber, pos.column)
-            .map(def => ({ ...def, uri: m.uri })),
+        provideTypeDefinition(m, pos) {
+            const list = state.type_definition(pos.lineNumber, pos.column);
+            if (list) {
+                return list.map(def => ({ ...def, uri: m.uri }));
+            }
+        },
     });
+    monaco.languages.registerDocumentSymbolProvider(modeId, {
+        provideDocumentSymbols: () => state.document_symbols(),
+    })
 
     class TokenState {
         constructor(line = 0) {
@@ -186,8 +200,10 @@ monaco.languages.onLanguage(modeId, async () => {
 
     function fixTag(tag) {
         switch (tag) {
+            case 'builtin': return 'variable.predefined';
+            case 'attribute': return 'key';
+            case 'macro': return 'number.hex';
             case 'literal': return 'number';
-            case 'function': return 'identifier';
             default: return tag;
         }
     }

--- a/wasm-demo/www/index.js
+++ b/wasm-demo/www/index.js
@@ -183,7 +183,14 @@ monaco.languages.onLanguage(modeId, async () => {
     });
     monaco.languages.registerDocumentSymbolProvider(modeId, {
         provideDocumentSymbols: () => state.document_symbols(),
-    })
+    });
+    monaco.languages.registerOnTypeFormattingEditProvider(modeId, {
+        autoFormatTriggerCharacters: [".", "="],
+        provideOnTypeFormattingEdits: (_, pos, ch) => state.type_formatting(pos.lineNumber, pos.column, ch),
+    });
+    monaco.languages.registerFoldingRangeProvider(modeId, {
+        provideFoldingRanges: () => state.folding_ranges(),
+    });
 
     class TokenState {
         constructor(line = 0) {


### PR DESCRIPTION
- goto document symbol
- goto implementation
- folding ranges provided by rust-analyzer

I've removed logging dependencies for release build as they slow down all editor actions, this should also reduce wasm size a bit.
