### PR TITLE
fix link to rust-analyzer source

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ layout: default
         Bringing <em>great</em> IDE experience to the Rust programming language.
     </p>
 
-    <a class="source" href="https://rust-analyzer.github.io/">
+    <a class="source" href="https://github.com/rust-analyzer/rust-analyzer">
         <img src="/assets/github.svg"> Source
     </a>
 </section>


### PR DESCRIPTION
I'm guessing that the source link was intended to link to the rust-analyzer source, instead of back to the current page.