### PR TITLE
Add date to blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,5 +3,6 @@ layout: default
 ---
 <article>
 <h1>{{ page.title }}</h1>
+<div class="post-meta sect1">{{ page.date | date: "%b %-d, %Y" }}</div>
 {{ content }}
 </article>


### PR DESCRIPTION
I took a naive stab at this, plopping the date under the post title with some existing styles. Adjust as you see fit!

Fixes #50.