### PR TITLE
Improve layout of sponsors

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -133,18 +133,21 @@ a.source:hover {
 
 .sponsors {
     font-size: 1.21875em;
+    margin: 0 0 1.25em;
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: stretch;
+    flex-wrap: wrap;
 }
 
-.sponsors > ul {
+.sponsors li {
+    list-style-type: none;
+    white-space: nowrap;
+    margin: 0 0.75em;
+    flex-basis: 0;
     flex-grow: 1;
-    align-self: center;
-}
-
-.sponsors > ul > li {
-    list-style: none;
+    text-align: center;
 }
 
 .post-list {

--- a/index.html
+++ b/index.html
@@ -71,16 +71,12 @@ layout: default
     <p>
         The following companies contributed significantly towards rust-analyzer development:
     </p>
-    <div class="sponsors">
-        <ul>
-            <li><a href="https://ferrous-systems.com/">Ferrous Systems</a></li>
-            <li><a href="https://www.mozilla.org/">Mozilla</a></li>
-        </ul>
-        <ul>
-            <li><a href="https://embark-studios.com">Embark Studios</a></li>
-            <li><a href="https://www.freiheit.com/">freiheit.com</a></li>
-        </ul>
-    </div>
+    <ul class="sponsors">
+        <li><a href="https://ferrous-systems.com/">Ferrous Systems</a></li>
+        <li><a href="https://www.mozilla.org/">Mozilla</a></li>
+        <li><a href="https://embark-studios.com">Embark Studios</a></li>
+        <li><a href="https://www.freiheit.com/">freiheit.com</a></li>
+    </ul>
 
 </section>
 


### PR DESCRIPTION
Use a flex layout for sponsors that wraps on smaller screens and never breaks company names into multiple lines.

Desktop:

![sponsors1](https://user-images.githubusercontent.com/15658558/90409783-e556fe80-e0a9-11ea-8947-d3d633cd6cfa.png)

Mobile:

![sponsors2](https://user-images.githubusercontent.com/15658558/90409793-ea1bb280-e0a9-11ea-9133-aea87bf9bfa4.png)
