### PR TITLE
Explain manual installation in VS Code

### DIFF
--- a/manual.adoc
+++ b/manual.adoc
@@ -95,6 +95,23 @@ If you don't want to be asked for `Download now` every day when the new nightly 
 
 NOTE: Nightly extension should **only** be installed via the `Download now` action from VS Code.
 
+==== Manual installation
+
+Alternatively, procure both `rust-analyzer.vsix` and your platform's matching `rust-analyzer-{platform}`, for example from the
+https://github.com/rust-analyzer/rust-analyzer/releases[releases] page.
+
+Install the extension with the `Extensions: Install from VSIX` command within VS Code, or from the command line via:
+[source]
+----
+$ code --install-extension /path/to/rust-analyzer.vsix
+----
+
+Copy the `rust-analyzer-{platform}` binary anywhere, then add the path to your settings.json, for example:
+[source,json]
+----
+{ "rust-analyzer.serverPath": "~/.local/bin/rust-analyzer-linux" }
+----
+
 ==== Building From Source
 
 Alternatively, both the server and the plugin can be installed from source:


### PR DESCRIPTION
I spent way too much time on an offline installation, and I'm hoping this documentation change might save others the same trouble.

Copying rust-analyzer-{platform} into the path mentioned in the documentation (`.../User/globalStorage/matklad.rust-analyzer`) doesn't do anything - the `globalState.serverVersion` magic prevents the extension from using the file unless the extension has previously downloaded something there.

Manually providing a rust-analyzer binary always requires setting serverPath, and the documentation will now reflect that.