### PR TITLE
Add Kate installation section

### DIFF
--- a/manual.adoc
+++ b/manual.adoc
@@ -385,7 +385,7 @@ If available in PATH or in some standard location, `rust-analyzer` is detected a
 If `rust-analyzer` is not detected, Corrosion will prompt you for configuration of your Rust toolchain and language server with a link to the __Window > Preferences > Rust__ preference page; from here a button allows to download and configure `rust-analyzer`, but you can also reference another installation.
 You'll need to close and reopen all .rs and Cargo files, or to restart the IDE, for this change to take effect.
 
-=== Kate Text Editor ===
+=== Kate Text Editor
 
 Support for language server protocol is built into included by default Kate plugin Lsp.
 It is preconfigurde to use Rls for rust sources by a simple settings change allows to use rust-analyzer instead.

--- a/manual.adoc
+++ b/manual.adoc
@@ -391,23 +391,25 @@ Support for language server protocol is built into included by default Kate plug
 It is preconfigurde to use Rls for rust sources by a simple settings change allows to use rust-analyzer instead.
 In Kate settings, LSP client, copy the content of the third tab "default parameters" to the second tab "server configuration".
 Then in the configuration replace :
-```
+[source,json]
+----
         "rust": {
             "command": ["rls"],
             "rootIndicationFileNames": ["Cargo.lock", "Cargo.toml"],
             "url": "https://github.com/rust-lang/rls",
             "highlightingModeRegex": "^Rust$"
         },
-```
+----
 By
-```
+[source,json]
+----
         "rust": {
             "command": ["rust-analyzer"],
             "rootIndicationFileNames": ["Cargo.lock", "Cargo.toml"],
             "url": "https://github.com/rust-analyzer/rust-analyzer",
             "highlightingModeRegex": "^Rust$"
         },
-```
+----
 Then click on apply, and restart the LSP server for your rust project.
 
 == Configuration

--- a/manual.adoc
+++ b/manual.adoc
@@ -385,6 +385,31 @@ If available in PATH or in some standard location, `rust-analyzer` is detected a
 If `rust-analyzer` is not detected, Corrosion will prompt you for configuration of your Rust toolchain and language server with a link to the __Window > Preferences > Rust__ preference page; from here a button allows to download and configure `rust-analyzer`, but you can also reference another installation.
 You'll need to close and reopen all .rs and Cargo files, or to restart the IDE, for this change to take effect.
 
+=== Kate Text Editor ===
+
+Support for language server protocol is built into included by default Kate plugin Lsp.
+It is preconfigurde to use Rls for rust sources by a simple settings change allows to use rust-analyzer instead.
+In Kate settings, LSP client, copy the content of the third tab "default parameters" to the second tab "server configuration".
+Then in the configuration replace :
+```
+        "rust": {
+            "command": ["rls"],
+            "rootIndicationFileNames": ["Cargo.lock", "Cargo.toml"],
+            "url": "https://github.com/rust-lang/rls",
+            "highlightingModeRegex": "^Rust$"
+        },
+```
+By
+```
+        "rust": {
+            "command": ["rust-analyzer"],
+            "rootIndicationFileNames": ["Cargo.lock", "Cargo.toml"],
+            "url": "https://github.com/rust-analyzer/rust-analyzer",
+            "highlightingModeRegex": "^Rust$"
+        },
+```
+Then click on apply, and restart the LSP server for your rust project.
+
 == Configuration
 
 **Source:** https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/rust-analyzer/src/config.rs[config.rs]

--- a/manual.adoc
+++ b/manual.adoc
@@ -387,10 +387,10 @@ You'll need to close and reopen all .rs and Cargo files, or to restart the IDE, 
 
 === Kate Text Editor
 
-Support for language server protocol is built into included by default Kate plugin Lsp.
-It is preconfigurde to use Rls for rust sources by a simple settings change allows to use rust-analyzer instead.
-In Kate settings, LSP client, copy the content of the third tab "default parameters" to the second tab "server configuration".
-Then in the configuration replace :
+Support for the language server protocol is built into Kate through the LSP plugin, which is included by default.
+It is preconfigured to use Rls for rust sources, but allows you to use rust-analyzer through a simple settings change.
+In the LSP Client settings of Kate, copy the content of the third tab "default parameters" to the second tab "server configuration".
+Then in the configuration replace:
 [source,json]
 ----
         "rust": {
@@ -400,7 +400,7 @@ Then in the configuration replace :
             "highlightingModeRegex": "^Rust$"
         },
 ----
-By
+With
 [source,json]
 ----
         "rust": {


### PR DESCRIPTION
Kate editor has had LSP support for a while (https://invent.kde.org/utilities/kate/-/commit/9838d5decb94034535e2433213bcdd902650e9ba), preconfiguring it for RLS, but it can just as well support Rust-analyzer.