### PR TITLE
Clarify GNOME Builder setup instructions

### DIFF
--- a/manual.adoc
+++ b/manual.adoc
@@ -395,8 +395,8 @@ If you get an error saying `No such file or directory: 'rust-analyzer'`, see the
 
 === GNOME Builder
 
-GNOME Builder 3.37.1 and newer has native `rust-analyzer` support.
-If the LSP binary is not available, GNOME Builder can install it when opening a Rust file.
+GNOME Builder 3.37.1 and newer has native `rust-analyzer` support. 
+If the LSP binary is not available, you need to install it manually or use the Rust flatpak extension.
 
 
 === Eclipse IDE


### PR DESCRIPTION
Using GNOME Builder 41.3 I get these instructions: 

![image](https://user-images.githubusercontent.com/317239/145708585-18d0d3ce-ff54-4b72-8176-185439b694ab.png)
