### PR TITLE
Remove inlay hints notes about vscode not having native support

### DIFF
--- a/generated_features.adoc
+++ b/generated_features.adoc
@@ -344,10 +344,6 @@ rust-analyzer shows hints for
 * names of function arguments
 * types of chained expressions
 
-**Note:** VS Code does not have native support for inlay hints https://github.com/microsoft/vscode/issues/16221[yet] and the hints are implemented using decorations.
-This approach has limitations, the caret movement and bracket highlighting near the edges of the hint may be weird:
-https://github.com/rust-analyzer/rust-analyzer/issues/1623[1], https://github.com/rust-analyzer/rust-analyzer/issues/3453[2].
-
 |===
 | Editor  | Action Name
 


### PR DESCRIPTION
Just updating the information about the VSCode native inlay hints.

In the [Changelog #120](https://rust-analyzer.github.io/thisweek/2022/03/14/changelog-120.html) rust analyzer switched to upstream inlay hints.