### PR TITLE
Set the `experimental` document attribute to enable the keyboard macro

### DIFF
--- a/thisweek/_posts/2020-02-10-changelog-11.adoc
+++ b/thisweek/_posts/2020-02-10-changelog-11.adoc
@@ -1,5 +1,6 @@
 = Changelog #11
 :sectanchors:
+:experimental:
 :page-layout: post
 
 Commit: commit:5b703bdc582be427ee62d250b3d3290165c36b8c[] +

--- a/thisweek/_posts/2020-02-24-changelog-13.adoc
+++ b/thisweek/_posts/2020-02-24-changelog-13.adoc
@@ -1,5 +1,6 @@
 = Changelog #13
 :sectanchors:
+:experimental:
 :page-layout: post
 
 Commit: commit:cba3c991c8188e87363bbff190e9528606140808[] +

--- a/thisweek/_posts/2020-03-02-changelog-14.adoc
+++ b/thisweek/_posts/2020-03-02-changelog-14.adoc
@@ -1,5 +1,6 @@
 = Changelog #14
 :sectanchors:
+:experimental:
 :page-layout: post
 
 Commit: commit:2c8f136b162e795a32e7dff2d0456c323377575d[] +

--- a/thisweek/_posts/2020-03-16-changelog-16.adoc
+++ b/thisweek/_posts/2020-03-16-changelog-16.adoc
@@ -1,5 +1,6 @@
 = Changelog #16
 :sectanchors:
+:experimental:
 :page-layout: post
 
 Commit: commit:ebab250b6bffaafb347ce431d5f4c9eeab4aa7e3[] +

--- a/thisweek/_posts/2020-04-20-changelog-21.adoc
+++ b/thisweek/_posts/2020-04-20-changelog-21.adoc
@@ -1,5 +1,6 @@
 = Changelog #21
 :sectanchors:
+:experimental:
 :page-layout: post
 :!figure-caption:
 


### PR DESCRIPTION
I found that HTML outputs of some changelog posts such as [Changelog #11](https://rust-analyzer.github.io/thisweek/2020/02/10/changelog-11.html) contains raw keyboard macro expressions such as `kbd:[Enter]`.
This PR sets the `experimental` document attribute on those posts to make the macro processed.

I think it would be nice if the changelog draft has that attribute by default, so I will post a separate PR to change the draft generated by `xtask release`.