### PR TITLE
Windows binary install instructions, small binary install corrections…

### DIFF
--- a/manual.adoc
+++ b/manual.adoc
@@ -157,7 +157,7 @@ On Windows:
 . Extract the files
 . Copy the `rust-analyzer.exe` file to a suitable directory (e.g. `C:\tools`)
 . Add that directory to the user's *PATH* _environment variable_
-. Open a new `Command Prompt` or `PowerShell` to use `rust-analyzer` 
+. Restart your shell or command prompt and your editor to enable changes 
 
 Alternatively, you can install it from source using the command below.
 You'll need the latest stable version of the Rust toolchain.

--- a/manual.adoc
+++ b/manual.adoc
@@ -166,7 +166,6 @@ You'll need the latest stable version of the Rust toolchain.
 ----
 $ git clone https://github.com/rust-lang/rust-analyzer.git && cd rust-analyzer
 $ git checkout release
-$ cargo build --release
 $ cargo xtask install --server
 ----
 

--- a/manual.adoc
+++ b/manual.adoc
@@ -156,7 +156,7 @@ On Windows:
 . Download a suitable Windows specific release e.g. `rust-analyzer-x86_64-pc-windows-msvc.zip`
 . Extract the files
 . Copy the `rust-analyzer.exe` file to a suitable directory (e.g. `C:\tools`)
-. Add that directory to the user's *path* _environmental variable_
+. Add that directory to the user's *PATH* _environment variable_
 . Open a new `Command Prompt` or `PowerShell` to use `rust-analyzer` 
 
 Alternatively, you can install it from source using the command below.

--- a/manual.adoc
+++ b/manual.adoc
@@ -167,7 +167,6 @@ You'll need the latest stable version of the Rust toolchain.
 $ git clone https://github.com/rust-lang/rust-analyzer.git && cd rust-analyzer
 $ git checkout release
 $ cargo build --release
-$ git checkout release
 $ cargo xtask install --server
 ----
 

--- a/manual.adoc
+++ b/manual.adoc
@@ -136,6 +136,8 @@ Other editors generally require the `rust-analyzer` binary to be in `$PATH`.
 You can download pre-built binaries from the https://github.com/rust-lang/rust-analyzer/releases[releases] page.
 You will need to uncompress and rename the binary for your platform, e.g. from `rust-analyzer-aarch64-apple-darwin.gz` on Mac OS to `rust-analyzer`, make it executable, then move it into a directory in your `$PATH`.
 
+Use either this binary install or <<rustup>> for `rust-analyzer`. Do not mix this binary install with a `rustup` upgrade or vice versa. 
+
 On Linux to install the `rust-analyzer` binary into `~/.local/bin`, these commands should work:
 
 [source,bash]
@@ -149,12 +151,23 @@ Make sure that `~/.local/bin` is listed in the `$PATH` variable and use the appr
 
 You don't have to use `~/.local/bin`, any other path like `~/.cargo/bin` or `/usr/local/bin` will work just as well.
 
+On Windows:
+
+. Download a suitable Windows specific release e.g. `rust-analyzer-x86_64-pc-windows-msvc.zip`
+. Extract the files
+. Copy the `rust-analyzer.exe` file to a suitable directory (e.g. `C:\tools`)
+. Add that directory to the user's *path* _environmental variable_
+. Open a new `Command Prompt` or `PowerShell` to use `rust-analyzer` 
+
 Alternatively, you can install it from source using the command below.
 You'll need the latest stable version of the Rust toolchain.
 
 [source,bash]
 ----
 $ git clone https://github.com/rust-lang/rust-analyzer.git && cd rust-analyzer
+$ git checkout release
+$ cargo build --release
+$ git checkout release
 $ cargo xtask install --server
 ----
 
@@ -169,6 +182,8 @@ On Unix, running the editor from a shell or changing the `.desktop` file to set 
 ----
 $ rustup component add rust-analyzer
 ----
+
+Use either <<rust-analyzer-language-server-binary, rust-analyzer binary>> or `rustup` for `rust-analyzer`. Do not mix a binary install with a `rustup` upgrade or the other way around. 
 
 ==== Arch Linux
 


### PR DESCRIPTION
I had a number of issues getting rust-analyzer to work on my windows machine. Mostly down to my poor understanding of how this worked. I have adjusted to documentation to make it clearer, I hope, for other people

I also discovered that the "install it from source" instructions needed a `cargo build` before issuing the `cargo xtask` command.

There are conflicts between the proxy installation of `rustup` and the `binary installed` version (owing to the proxy of rustup). I have added some notes to make it clear that this should not be mixed and matched.

For the record, I use this with helix. I like it a lot. (I have used VS Code and neovim editors recently).