### PR TITLE
Fix dark theme logo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,7 +35,7 @@
   {% if page.url != "/" %}
   <header>
     <div id="header-inner">
-      <div id="header-left">
+      <div class="nightowl-daylight" id="header-left">
         <a class="site-title" href="{{ site.baseurl }}/">
           <img src="/assets/rust-analyzer.svg" alt="rust analyzer" id="header-logo">
         </a>


### PR DESCRIPTION
NOTE: I cannot test this because I'm having problems installing the dependencies, if someone could test this, it would be great!

This commit fixes the logo in `thisweek` urls to have the `nightowl-daylight` class, just like in the homepage
Fixes #219 