### PR TITLE
ci: update mdbook to 0.4.45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.4.40
+          tool: mdbook@0.4.45
 
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
mdbook has had a solid number of commits since 0.4.40, update to the latest version.